### PR TITLE
Introduce ArcGIS Rest Servers entry

### DIFF
--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -357,13 +357,13 @@ Here you will find a read-only list of all your Open Web Services (OWS)
 - WMS / WCS / WFS / ...
 
 
-ArcGIS Map Service
+ArcGIS Rest Servers
 ......................................................................
+*ArcGIS Feature Services* and *ArcGIS Map Services*
 
-
-ArcGIS Features Service
-......................................................................
-
+From the top level context menu, you add an existing service
+(:guilabel:`New Connection...`), and you can
+:guilabel:`Save Connections...` or :guilabel:`Load Connections...`.
 
 GeoNode
 ......................................................................


### PR DESCRIPTION
Adds a section to Introduction / Browser Panel to describe "ArcGIS Rest Servers" to fix #6381.

Still to do / potentially as part of this fix:
- replace screenshot (shows separate entries for "ArcGIS Feature Services" and "ArcGIS Map Services"
- add additional info about: connecting to ArcGIS server, differences between adding a feature service vs a map service if any, options once connection is created

Other pages that mention ArcGIS Feature Services or ArcGIS Map Services, but at current level of detail don't seem worth updating:
docs/user_manual/plugins/core_plugins/plugins_metasearch.rst
docs/user_manual/introduction/qgis_gui.rst

N00b alert: This is my first PR to this project, thanks for any comments from veterans and please don't assume I know anything ;)!